### PR TITLE
Merge user defaultHeaders with built-in defaults instead of replacing

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -566,9 +566,12 @@ export class SessionClient {
         this.defaultOptions = {
             ...DEFAULT_OPTIONS,
             headerOrder: [...(DEFAULT_OPTIONS.headerOrder ?? [])],
-            defaultHeaders: { ...DEFAULT_OPTIONS.defaultHeaders },
             retryStatusCodes: [...(DEFAULT_OPTIONS.retryStatusCodes ?? [])],
             ...options,
+            defaultHeaders:
+                options.defaultHeaders === null
+                    ? null
+                    : { ...DEFAULT_OPTIONS.defaultHeaders, ...options.defaultHeaders },
         };
 
         this.sessionId = crypto.randomUUID();


### PR DESCRIPTION
Fixes #19

## Problem

Passing `defaultHeaders` to the `SessionClient` constructor replaced the entire built-in default header object. Since the built-in defaults carry the Chrome `User-Agent`, any session configured with custom `defaultHeaders` (e.g. just `sec-fetch-mode` / `sec-fetch-site`) silently lost its User-Agent and sent requests as `Go-http-client/2.0` — defeating the point of a TLS-fingerprinting client.

This was also inconsistent with per-request `headers`, which already merge over `defaultHeaders` in `combineOptions`.

## Fix

User-supplied `defaultHeaders` now merge over `DEFAULT_OPTIONS.defaultHeaders` in the constructor, so the built-in User-Agent is preserved unless explicitly overridden:

- `defaultHeaders: { 'sec-fetch-mode': 'cors' }` → merged with the default User-Agent
- `defaultHeaders: { 'User-Agent': 'Custom/1.0' }` → override still works
- `defaultHeaders: null` → still clears all default headers (explicit opt-out preserved)

## Verification

Type-check and build pass. Verified all three cases at runtime by inspecting `session.defaultOptions.defaultHeaders` after construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012FNCPow4fncEvC1tJHrehE

---
_Generated by [Claude Code](https://claude.ai/code/session_012FNCPow4fncEvC1tJHrehE)_