### PR TITLE
Validate HTTP/2 header casing and lowercase default user-agent

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -508,7 +508,7 @@ const DEFAULT_OPTIONS: TlsClientDefaultOptions = {
         'accept-datetime',
     ],
     defaultHeaders: {
-        'User-Agent':
+        'user-agent':
             'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/146.0.0.0 Safari/537.36',
     },
     connectHeaders: null,
@@ -560,6 +560,15 @@ export class SessionClient {
 
         if (!(moduleClient instanceof ModuleClient)) {
             throw new Error('ModuleClient must be an instance of ModuleClient');
+        }
+
+        const allHeaders = [...Object.keys(options.defaultHeaders ?? {}), ...Object.keys(options.connectHeaders ?? {})]
+        if (options.forceHttp1 !== true) {
+            for (const header of allHeaders) {
+                if (header !== header.toLowerCase()) {
+                    throw new Error(`HTTP/2 header must be lowercase for fingerprint consistency: ${header}`);
+                }
+            }
         }
 
         // Copy nested mutables so one session's edits never bleed into another


### PR DESCRIPTION
Added HTTP/2 header casing validation to the `SessionClient` constructor. When `forceHttp1` is `false`, both `defaultHeaders` and `connectHeaders` are checked, and an error is thrown if any header name is not lowercase.

Renamed the `user-agent` header in `DEFAULT_OPTIONS.defaultHeaders` to lowercase.

No header casing validation is performed when `forceHttp1` is `true`, since HTTP/1.1 does not require lowercase header names

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized the default `User-Agent` header key to lowercase.
  * Added validation for default and CONNECT header names when HTTP/1 is not forced, preventing invalid non-lowercase headers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->